### PR TITLE
Replace FTDI download link with link to executable

### DIFF
--- a/articles/intro.md
+++ b/articles/intro.md
@@ -6,7 +6,7 @@ All [Harp Devices](https://harp-tech.org/Devices/device_list.html) implement the
 ## Pre-requisites
 
 1. [Bonsai](https://bonsai-rx.org)
-2. [FTDI D2XX Drivers](https://www.ftdichip.com/old2020/Drivers/CDM/CDM%20v2.12.26%20WHQL%20Certified.zip)
+2. [FTDI D2XX Drivers](https://ftdichip.com/wp-content/uploads/2021/08/CDM212364_Setup.zip)
 
 ## How to install
 


### PR DESCRIPTION
The previous link targeted a zip file with DLLs instead of an executable. For ease of use, I would suggest replacing it with this one. Unfortunately, the official developers no longer have a link for the executable of the current outdated version we are using. @filcarv Mentioned we can use the newer version and, looking at the release notes, it should be ok since no major changes seemed to have been made. 