### PR TITLE
Fix loop in reaction time task analysis script

### DIFF
--- a/tutorials/hobgoblin-reaction.md
+++ b/tutorials/hobgoblin-reaction.md
@@ -115,6 +115,7 @@ for led_on in digital_output_set.index:
         response_time = button_press - led_on
         if 0 < response_time < response_window:
             valid_response_times.append(response_time)
+            break
 
 # Calculate and print hit/miss percentage
 num_valid_responses = len(valid_response_times)


### PR DESCRIPTION
The code that loops through stimulus presentation and button presses to extract valid responses is currently missing a `break`. It should break out of the inner `for` loop once the first button press has been found, otherwise it will add the other button presses as well.